### PR TITLE
Update navigation.html

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -3,7 +3,7 @@
     <li><a href="#get-started">Download</a></li>
     <li><a href="#learn-more">Learn</a></li>
     <li><a href="#tips--tricks">Tips</a></li>
-    <li><a href="https://uselessshit.co/resources/nostr/" target="_blank">FAQ</a></li>
+    <li><a href="https://swarmstr.com" target="_blank">Q&A</a></li>
     <li><a href="#translations" title="Translations"><i class="fa fa-language"></i></a></li>
     <li><a href="https://github.com/nostr-resources/nostr-resources.github.io" title="GitHub"><i class="fa fa-code-fork"></i></a></li>
   </ul>


### PR DESCRIPTION
I updated the link to point to https://swarmstr.com along with the link text - I think it makes more sense to call it Q&A now (swarmstr is a q&a nostr client)