### PR TITLE
Add nostrich.house to nip05 providers

### DIFF
--- a/_data/nip05providers.yml
+++ b/_data/nip05providers.yml
@@ -33,3 +33,7 @@
 - name: nostr-relay.org
   link: https://nostr-relay.org
   price: 1000 sats
+
+- name: Nostrich.House
+  link: https://nostrich.house/
+  price: 1 sat / hour


### PR DESCRIPTION
nostrich.house has a NIP-04 DM interface to create nip-05 entities immediately by bot conversation in the Nostr. It's paid by zapping 1 sat per hour to the bot.