### PR TITLE
Updates throughout for July & August 2025

### DIFF
--- a/index.md
+++ b/index.md
@@ -72,7 +72,10 @@ Download a suitable client:
 # FAQ
 
 **What's the easiest way to create a profile?**  
-🦚 Going to [nstart.me](https://nstart.me/) is probably easiest. There is also [nosta.me](https://nosta.me/)
+🦚 Going to [nstart.me](https://nstart.me/) is probably easiest. Thw wizard will walk you through
+account setup, key management, and even help you build your following list. There is also [nosta.me](https://nosta.me/)
+which offers some introduction to relays and other activities you can do on nostr.
+
 
 **What is the best nostr client?**  
 🦚 There is no best. You'll have to [pick a client](#clients) according to your
@@ -95,8 +98,8 @@ you and can be used to look up your profile and initiate a connection with you,
 either via a follow, a DM, or a zap.
 
 **What are zaps?**  
-🦚 Zaps are nostr's way of seamlessly transferring value between users. They are
-neither "tips" nor "expensive likes," but a new way of expressing value and
+🦚 Zaps are nostr's way of seamlessly transferring value between users. [They are
+neither "tips" nor "expensive likes"](https://njump.me/nevent1qvzqqqqqqypzqmjxss3dld622uu8q25gywum9qtg4w4cv4064jmg20xsac2aam5nqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgwwaehxw309ahx7uewd3hkctcqyqx6hc4glxnhergs086yp77ne8cdt8zt5z99r4lcz88whfvtq23920ynxd7), but a new way of expressing value and
 counterfeit-resistant engagement. They are [sat-based][br] tokens of appreciation with
 perfect scarcity. They are, as one nostrich so beautifully put it, a way to say:
 [keep doing you][kdy]. Zaps are flowing through the system at all times, as you
@@ -155,7 +158,7 @@ To use nostr, you need a [key](#keys) and a [client](#clients).
 - Everybody runs a client. It can be a native client, a web client, etc.
 - To publish something, you write a post, sign it with your key and send it to multiple relays (servers hosted by someone else, or yourself).
 - To get updates from other people, you ask multiple relays if they know anything about these other people.
-- Anyone can run a relay. A relay is very simple and dumb. It does nothing besides accepting posts from some people and forwarding to others.
+- Anyone can run a relay. A relay is very simple. It does nothing besides accepting posts from some people and forwarding to others.
 - Relays don't have to be trusted. Signatures are verified on the client side.
 
 ## Keys
@@ -186,9 +189,10 @@ store your keys safely (or at least more safely).
 - [Nostr in the Alby Extension](https://blog.getalby.com/nostr-in-the-alby-extension/)
 - [The nos2x browser extension and why you should use it](https://youtu.be/IoLw-3ok3_M)
 
-If you're on Android, it is recommended to use a native signer like [Amber].
+If you're on mobile, it is recommended to use a native signer. There is [Amber] for Android. For iOS, there is [Nostash].
 
 [Amber]: https://github.com/greenart7c3/Amber?tab=readme-ov-file#download-and-install
+[Nostash]: https://apps.apple.com/us/app/nostash/id6744309333
 
 You can also generate your keys by other means if you know what you're doing.[^bip85]
 It's still early days, so be prepared to get rekt.
@@ -256,17 +260,18 @@ Desktop clients:
 
 ## Relays
 
-Relays are dumb servers that you can leave behind at any time (so they can't
-turn evil). You need to connect your client to a relay for it to work. There are
+Relays are simple servers that you can leave behind at any time (so they can't
+turn evil). [You need to connect your client to a relay for it to work](https://youtu.be/TFH7Xr0cJ0w). There are
 many relays & you can run your own.
 
 - [nostr.watch](http://nostr.watch/) - directory of paid and free relays
 - [nostr.info](https://nostr.info/relays/) directory of known nostr relays
-- [relay.tools](https://relay.tools/) - public relay browser
 
 Run your own:
 
 - [Set up a Nostr Relay server in under 5 minutes](https://andreneves.xyz/p/set-up-a-nostr-relay-server-in-under)[^fn-fork]
+- [relay.tools](https://relay.tools/) - hosted relay platform & public relay browser
+- [Citrine](https://github.com/greenart7c3/Citrine?tab=readme-ov-file#download) - a local relay for Android devices
 
 Paid relays:
 
@@ -294,13 +299,15 @@ nostr can do more than just social media.
 - [Emojis](https://emojito.meme/) - create or use emoji packs supported on most nostr clients.
 - [Pinja](https://www.pinja.in/) - pin urls as bookmarks.
 - [Lantern](https://chromewebstore.google.com/detail/lantern/jjoijlenmgefkaeiomoaelcljfibpcgh) - highlight, annotate, and discuss anything on the web.
-- [NsecBunker](https://nsecbunker.com/) - keep your nostr keys in a single place and provide fine-grained access to team members.
+- [Yakbak](https://yakbak.app/) - voice notes on nostr.
+- [Formstr](https://formstr.app/dashboard) - fillable, sharable forms.
 
 ## Games
 
 Games? WTF? Yes, games:
 
 - [Jester](https://jesterui.github.io/) - Chess over nostr by theborakompanioni
+- [Flappy Nostrich](https://flappy-nostrich.vercel.app/) - Navigate bitcoin price talk to reach good nostr content by [Ryan](npub1m64hnkh6rs47fd9x6wk2zdtmdj4qkazt734d22d94ery9zzhne5qw9uaks)
 
 ---
 


### PR DESCRIPTION
Not much to remove, lots to add. I expanded one of the FAQ answers to hopefully spur a little more action. Removed "dumb". People misinterpret that a lot.  Adds: 
- Flappy Nostrich
- Citrine
- Formstr
- Yakbak
- Nostash
- additional edu-resource links

Removes:
- nsecbunker, for now