### PR TITLE
Add Yakihonne, x21, Asknostr; update Damus to iOS & Android

### DIFF
--- a/index.md
+++ b/index.md
@@ -202,12 +202,13 @@ list of clients or have a look at the [client comparison table](https://github.c
 
 Mobile clients:
 
-- [Damus (iOS)](https://damus.io/) - Twitter-style iOS client, also works on MacOS[^fn-mac]
+- [Damus (iOS & Android)](https://damus.io/) - Twitter-style iOS/Android client, also works on MacOS[^fn-mac]
 - [Amethyst (Android)](https://www.amethyst.social/) - Twitter-style Android client
 - [Flotilla (Android)](https://play.google.com/store/apps/details?id=social.flotilla&hl=en_US) - DMs and group chats
 - [Nostur (iOS)](https://apps.apple.com/us/app/nostur/id1672780508) - native iOS/iPad client with MacOS[^fn-mac] version
 - [Openvibe (iOS & Android)](https://play.google.com/store/apps/details?id=com.plebstr.client) - Nostr, Threads, Bluesky, and Mastodon in one client.
 - [Primal (iOS & Android)](https://primal.net/downloads) - Clean & performant, but not very feature-rich (yet)
+- [Yakihonne (iOS & Android)](https://yakihonne.com/yakihonne-mobile-app) - Cross-platform Nostr client
 
 There are more native clients in development, Nostros[^nostros] and Voyage[^voyage] being two of them.
 
@@ -222,6 +223,7 @@ Web clients:
 - [coracle.social](https://coracle.social/) - Search, filters, and micro-apps
 - [jumble](https://jumble.social/]) - Explore content feeds by relay and create custom relay sets
 - [iris.to](https://iris.to/) - Clean interface & rich in features
+- [x21](https://x21.social/) - Clean interface
 - [nostria](https://nostria.app/) - Explore relay feeds, topics, music, and more
 - [grimoire](https://grimoire.rocks/) - A nostr client for magicians
 
@@ -297,6 +299,7 @@ Managing your nostr keys AND your profile is as essential as backing up your pri
 
 nostr can do more than just social media.
 
+- [Asknostr](https://asknostr.site) - Q&A platform (alternative to Quora/StackOverflow)
 - [Listr](https://listr.lol/) - create and manage lists to use in supporting nostr apps.
 - [nosbin](https://nosbin.com/) - pastebin over nostr.
 - [Zap.Cooking](https://zap.cooking/) - create, explore or share recipes.


### PR DESCRIPTION
Applies the same changes from #102 by @digitalbase, rebased cleanly on current main (stats entries from that PR were already merged separately).

- Update Damus listing to iOS & Android
- Add Yakihonne to mobile clients
- Add x21 to web clients
- Add Asknostr to other apps section