### PR TITLE
feat: add NIP-05 verification for _@nostr-resources.com

### DIFF
--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -1,0 +1,5 @@
+{
+  "names": {
+    "_": "d680bb82c5fa2e80c887158c6e3b8da4f435d99eb7710daadca3b484a063e398"
+  }
+}

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,8 @@ compress_html:
   clippings: all
   comments: all
   startings: [html, head, body]
+include:
+  - .well-known
 exclude:
   - env
   - scripts


### PR DESCRIPTION
Adds `.well-known/nostr.json` so that NIP-05 verification works for `_@nostr-resources.com`.

**Changes:**
- Add `.well-known/nostr.json` mapping `_` → Nostr Resources pubkey
- Add `include: [.well-known]` to `_config.yml` so Jekyll serves the directory

Once merged, `https://nostr-resources.com/.well-known/nostr.json` will return the correct pubkey mapping.